### PR TITLE
Show timezones

### DIFF
--- a/src/InboxComponent.vue
+++ b/src/InboxComponent.vue
@@ -188,7 +188,6 @@ export default {
     this.store.auth = this.auth;
 
     this.loading = true;
-    this.store.loadParticipant();
     this.store.loadMessages()
       .then(() => {
         this.loading = false;

--- a/src/InboxComponent.vue
+++ b/src/InboxComponent.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="component">
+  <div class="inbox-component">
+    <p>All texts are displayed in the participant's current time zone: {{ inboxHelper.getFriendlyTimezoneName() }}</p>
     <div>
       <div class="inbox">
         <div v-if="store.loading.older" class="text-center">
@@ -187,6 +188,7 @@ export default {
     this.store.auth = this.auth;
 
     this.loading = true;
+    this.store.loadParticipant();
     this.store.loadMessages()
       .then(() => {
         this.loading = false;

--- a/src/InboxComponent.vue
+++ b/src/InboxComponent.vue
@@ -2,7 +2,7 @@
   <div class="inbox-component">
     <p>All texts are displayed in the participant's current time zone: {{ inboxHelper.getFriendlyTimezoneName() }}</p>
     <div>
-      <div class="inbox">
+      <div class="inbox clearfix">
         <div v-if="store.loading.older" class="text-center">
           <b-spinner variant="primary" label="Spinning"/>
         </div>

--- a/src/helpers/inbox.js
+++ b/src/helpers/inbox.js
@@ -1,6 +1,19 @@
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(advancedFormat);
 
 let helper = {
+  tz: "America/New_York",
+  setTimezone(tz) {
+    this.tz = tz;
+  },
+  getFriendlyTimezoneName() {
+    return dayjs().tz(this.tz).format("zzz");
+  },
   statusType: function(msg) {
     switch (msg.status) {
       case 'delivered':
@@ -22,22 +35,22 @@ let helper = {
   },
   messageTime: function(msg) {
     let datetime = msg.sent_at || msg.created_at;
-    return dayjs(datetime).format('h:mm A');
+    return dayjs(datetime).tz(this.tz).format('h:mm A');
   },
   tooltipTime: function(msg) {
     let datetime = msg.sent_at || msg.created_at;
-    return dayjs(datetime).format('h:mm:ss A');
+    return dayjs(datetime).tz(this.tz).format('h:mm:ss A z');
   },
   messageDetailTime: function(msg) {
     let datetime = msg.sent_at || msg.created_at;
-    return dayjs(datetime).format('M/D/YY h:mm:ss A');
+    return dayjs(datetime).tz(this.tz).format('M/D/YY h:mm:ss A z');
   },
   imageDetailTime: function(msg) {
     let datetime = msg.sent_at || msg.created_at;
-    return dayjs(datetime).format('dddd, D MMMM YYYY – h:mm:ss A');
+    return dayjs(datetime).tz(this.tz).format('dddd, D MMMM YYYY – h:mm:ss A');
   },
   formatDate: function(date) {
-    return dayjs(date).format('~ dddd, D MMMM YYYY ~');
+    return dayjs(date).tz(this.tz).format('~ dddd, D MMMM YYYY ~');
   },
   formatNumber: function(number) {
     // +12345678901 -> 234-567-8901

--- a/src/stores/inbox.js
+++ b/src/stores/inbox.js
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import inboxHelper from '../helpers/inbox';
 
 let appState = {
   messagesObj: {},
@@ -52,6 +53,19 @@ let appState = {
   },
   getImageUrl(msgId, imageIndex) {
     return `${this.apiBaseUrl}/api/v2/text_messages/${msgId}/image/${imageIndex}`;
+  },
+  async loadParticipant() {
+    let auth = this.authCredentials();
+    let requestParams = Object.assign(auth, {
+      method: "GET"
+    });
+    const url = `${this.apiBaseUrl}/api/v2/participants/${this.participantId}?include=text_messages:limit(${this.meta.limit})`;
+    let res = await fetch(url, requestParams);
+    if (!res.ok) {
+      throw new Error("womp");
+    }
+    const ppt = (await res.json()).data;
+    inboxHelper.setTimezone(ppt?.time_zone_name ?? "America/New_York");
   },
   async fetchMessages(params, update = true) {
     let auth = this.authCredentials();

--- a/src/stores/inbox.js
+++ b/src/stores/inbox.js
@@ -54,19 +54,6 @@ let appState = {
   getImageUrl(msgId, imageIndex) {
     return `${this.apiBaseUrl}/api/v2/text_messages/${msgId}/image/${imageIndex}`;
   },
-  async loadParticipant() {
-    let auth = this.authCredentials();
-    let requestParams = Object.assign(auth, {
-      method: "GET"
-    });
-    const url = `${this.apiBaseUrl}/api/v2/participants/${this.participantId}?include=text_messages:limit(${this.meta.limit})`;
-    let res = await fetch(url, requestParams);
-    if (!res.ok) {
-      throw new Error("womp");
-    }
-    const ppt = (await res.json()).data;
-    inboxHelper.setTimezone(ppt?.time_zone_name ?? "America/New_York");
-  },
   async fetchMessages(params, update = true) {
     let auth = this.authCredentials();
     let requestParams = Object.assign(auth, {


### PR DESCRIPTION
Display timezone for participant at top and include it in tooltop and popover, as well as adjusting times using it.

Still want to refactor loadMessages to use the participant endpoint so we can make a single request. This requires a change to the API as well before it will work for anyone outside of eastern time.