### PR TITLE
Keep messages separated by participant on pages that show multiple participants

### DIFF
--- a/src/InboxComponent.vue
+++ b/src/InboxComponent.vue
@@ -99,7 +99,7 @@
 
 <script>
 
-import store from './stores/inbox';
+import InboxStore from "./stores/inbox";
 import styles from './stores/styles';
 import inboxHelper from './helpers/inbox';
 import manualModeHelper from './helpers/manualMode';
@@ -166,7 +166,7 @@ export default {
     return {
       scrolled: false,
       styleConfig: Object.assign(styles, this.styles),
-      store,
+      store: null,
       inboxHelper,
       manualModeHelper,
       textContent: "",
@@ -214,7 +214,7 @@ export default {
     }
   },
   async created() {
-    this.store.init(
+    this.store = new InboxStore(
       this.apiBaseUrl,
       this.participantId,
       this.studyId,
@@ -271,11 +271,11 @@ export default {
         if (inboxDiv) {
           if (this.galleryView) {
             if (inboxDiv.scrollTop >= inboxDiv.scrollHeight - inboxDiv.clientHeight - 1) {
-              store.loadOlder();
+              this.store.loadOlder();
             }
           } else {
             if (inboxDiv.scrollTop === 0) {
-              store.loadOlder();
+              this.store.loadOlder();
             }
           }
         }

--- a/src/InboxComponent.vue
+++ b/src/InboxComponent.vue
@@ -214,10 +214,12 @@ export default {
     }
   },
   async created() {
-    this.store.apiBaseUrl = this.apiBaseUrl;
-    this.store.participantId = this.participantId;
-    this.store.studyId = this.studyId;
-    this.store.auth = this.auth;
+    this.store.init(
+      this.apiBaseUrl,
+      this.participantId,
+      this.studyId,
+      this.auth,
+    );
 
     this.store.loadMessages()
       .then(() => {

--- a/src/stores/inbox.js
+++ b/src/stores/inbox.js
@@ -3,6 +3,14 @@ import inboxHelper from '../helpers/inbox';
 import manualModeHelper from '../helpers/manualMode';
 
 let appState = {
+  init(apiBaseUrl, participantId, studyId, auth) {
+    this.apiBaseUrl = apiBaseUrl;
+    this.participantId = participantId;
+    this.studyId = studyId;
+    this.auth = auth;
+
+    this.messagesObj = {};
+  },
   messagesObj: {},
   apiBaseUrl: null,
   participantId: null,

--- a/src/stores/inbox.js
+++ b/src/stores/inbox.js
@@ -1,222 +1,239 @@
-import dayjs from 'dayjs';
-import inboxHelper from '../helpers/inbox';
-import manualModeHelper from '../helpers/manualMode';
+import dayjs from "dayjs";
+import inboxHelper from "../helpers/inbox";
+import manualModeHelper from "../helpers/manualMode";
 
-let appState = {
-  init(apiBaseUrl, participantId, studyId, auth) {
-    this.apiBaseUrl = apiBaseUrl;
-    this.participantId = participantId;
-    this.studyId = studyId;
-    this.auth = auth;
+class InboxStore {
+    constructor(apiBaseUrl, participantId, studyId, auth) {
+        this.apiBaseUrl = apiBaseUrl;
+        this.participantId = participantId;
+        this.studyId = studyId;
+        this.auth = auth;
 
-    this.messagesObj = {};
-  },
-  messagesObj: {},
-  apiBaseUrl: null,
-  participantId: null,
-  studyId: null,
-  auth: {
-    method: "session",
-    apiKey: ""
-  },
-  meta: {
-    lastUpdated: null,
-    oldest: null,
-    pageSize: 50
-  },
-  loading: {
-    older: false,
-    initial: false,
-    polling: false,
-    send: false
-  },
-  imageCache: {},
-  authCredentials() {
-    if (this.auth.method === 'session') {
-      return {
-        credentials: "include"
-      }
-    } else if (this.auth.apiKey.length > 0) {
-      return {
-        headers: new Headers({
-          'Authorization': 'Bearer ' + this.auth.apiKey,
-        })
-      }
-    }
-  },
-  async fetchImage(url) {
-    if (this.imageCache[url]) {
-      return this.imageCache[url];
+        this.messagesObj = {};
+
+        this.meta = {
+            lastUpdated: null,
+            oldest: null,
+            pageSize: 50
+        };
+        this.loading = {
+            older: false,
+            initial: false,
+            polling: false,
+            send: false
+        };
+        this.imageCache = {};
     }
 
-    let auth = this.authCredentials();
-    let requestParams = Object.assign(auth, {
-      method: "GET"
-    });
-    let res = await fetch(url, requestParams);
-    let blob = await res.blob();
-
-    this.imageCache[url] = URL.createObjectURL(blob);
-
-    return this.imageCache[url];
-  },
-  getImageUrl(msgId, imageIndex) {
-    return `${this.apiBaseUrl}/api/v2/text_messages/${msgId}/image/${imageIndex}`;
-  },
-  async enableManualMode() {
-    const requestParams = Object.assign(
-      this.authCredentials(),
-      {
-        method: "POST",
-        body: JSON.stringify({
-          mode: "Manual",
-          duration_mins: 15
-        })
-      }
-    );
-    await fetch(`${this.apiBaseUrl}/api/v2/participants/${this.participantId}/messaging_mode_session`, requestParams);
-
-    // reload participant state including messaging mode and conversations
-    return this.loadMessages();
-  },
-  async disableManualMode() {
-    const requestParams = Object.assign(
-      this.authCredentials(),
-      {
-        method: "PATCH",
-        body: JSON.stringify([
-          {op: "end"}
-        ])
-      }
-    );
-
-    await fetch(`${this.apiBaseUrl}/api/v2/participants/${this.participantId}/messaging_mode_session`, requestParams);
-    // reload participant state including messaging mode and conversations
-    return this.loadMessages();
-  },
-  async fetchMessages(params, update = true) {
-    let auth = this.authCredentials();
-    let requestParams = Object.assign(auth, {
-      method: "GET"
-    });
-
-    let search = new URLSearchParams(Object.assign({
-      study_id: this.studyId,
-      participant_id: this.participantId,
-      order_by: 'desc(id)',
-      per_page: this.meta.pageSize
-    }, params));
-
-    let res = await fetch(`${this.apiBaseUrl}/api/v2/text_messages?` + search, requestParams);
-
-    if (!res.ok) {
-      throw new Error("womp");
-    }
-
-    let messages = (await res.json()).data;
-    return this.pullMessagesFromData(messages, update);
-  },
-  pullMessagesFromData(messages, update = true) {
-    if (update) {
-      // Our API call finds items updated after the lastUpdated, so if the lastUpdated matched the updated_at
-      // of a text we wouldn't get it. Move the search back by a second to account for that
-      this.meta.lastUpdated = dayjs().subtract(1, 'second').format('YYYY-MM-DD HH:mm:ss');
-    }
-
-    if (messages.length) {
-      let newMessages = messages.reduce((accumulator, text) => {
-        if (!this.meta.oldest || text.created_at < this.meta.oldest) {
-          this.meta.oldest = text.created_at;
+    authCredentials() {
+        if (this.auth.method === 'session') {
+            return {
+                credentials: "include"
+            }
+        } else if (this.auth.apiKey.length > 0) {
+            return {
+                headers: new Headers({
+                    'Authorization': 'Bearer ' + this.auth.apiKey,
+                })
+            }
         }
-        return {...accumulator, [text.id]: text};
-      }, {});
-      this.messagesObj = Object.assign({}, this.messagesObj, newMessages)
-    }
-  },
-  async loadMessages() {
-    if (this.loading.initial) {
-      return false;
-    }
-    this.loading.initial = true;
-    await this.loadMessagesViaParticipantApi(`limit(${this.meta.pageSize})`);
-    this.loading.initial = false;
-  },
-  async poll() {
-    if (this.loading.polling) {
-      return false;
-    }
-
-    this.loading.polling = true;
-    await this.loadMessagesViaParticipantApi(`updatedAfter(${this.meta.lastUpdated})`)
-    this.loading.polling = false;
-  },
-  async loadMessagesViaParticipantApi(textMessageCriteria) {
-    // use the participants endpoint for the initial load and when polling, so we get info on timezone, conversations,
-    // and messaging mode
-    let auth = this.authCredentials();
-    let requestParams = Object.assign(auth, {
-      method: "GET"
-    });
-    const includes = [
-      `text_messages:${textMessageCriteria}`,
-      'messaging_mode_session',
-      'current_conversation',
-    ];
-    const url = `${this.apiBaseUrl}/api/v2/participants/${this.participantId}?include=${includes.join(',')}`;
-    let res = await fetch(url, requestParams);
-    if (!res.ok) {
-      throw new Error("womp");
-    }
-    const ppt = (await res.json()).data;
-    inboxHelper.setTimezone(ppt?.time_zone_name ?? "America/New_York");
-    manualModeHelper.setCurrentSession(ppt?.messaging_mode_session);
-    manualModeHelper.setCurrentConversation(ppt?.current_conversation);
-    this.pullMessagesFromData(ppt.text_messages, true);
-
-  },
-  async loadOlder() {
-    if (this.loading.older) {
-      return false;
-    }
-
-    let params = {
-      created_at: 'before(' + this.meta.oldest + ')',
     };
 
-    this.loading.older = true;
-    await this.fetchMessages(params, false);
-    this.loading.older = false;
-  },
-  async sendMessage(message, imageUrl) {
-    if (this.loading.send) {
-      return false;
+    async fetchImage(url) {
+        if (this.imageCache[url]) {
+            return this.imageCache[url];
+        }
+
+        let auth = this.authCredentials();
+        let requestParams = Object.assign(auth, {
+            method: "GET"
+        });
+        let res = await fetch(url, requestParams);
+        let blob = await res.blob();
+
+        this.imageCache[url] = URL.createObjectURL(blob);
+
+        return this.imageCache[url];
+    };
+
+    getImageUrl(msgId, imageIndex) {
+        return `${this.apiBaseUrl}/api/v2/text_messages/${msgId}/image/${imageIndex}`;
+    };
+
+    async enableManualMode() {
+        const requestParams = Object.assign(
+            this.authCredentials(),
+            {
+                method: "POST",
+                body: JSON.stringify({
+                    mode: "Manual",
+                    duration_mins: 15
+                })
+            }
+        );
+        await fetch(`${this.apiBaseUrl}/api/v2/participants/${this.participantId}/messaging_mode_session`, requestParams);
+
+        // reload participant state including messaging mode and conversations
+        return this.loadMessages();
+    };
+
+    async disableManualMode() {
+        const requestParams = Object.assign(
+            this.authCredentials(),
+            {
+                method: "PATCH",
+                body: JSON.stringify([
+                    {op: "end"}
+                ])
+            }
+        );
+
+        await fetch(`${this.apiBaseUrl}/api/v2/participants/${this.participantId}/messaging_mode_session`, requestParams);
+        // reload participant state including messaging mode and conversations
+        return this.loadMessages();
     }
-    let body = {
-      message_text: message,
-      media_url: imageUrl,
-      force: true
+
+
+
+    async fetchMessages(params, update = true) {
+        let auth = this.authCredentials();
+        let requestParams = Object.assign(auth, {
+            method: "GET"
+        });
+
+        let search = new URLSearchParams(Object.assign({
+            study_id: this.studyId,
+            participant_id: this.participantId,
+            order_by: 'desc(id)',
+            per_page: this.meta.pageSize
+        }, params));
+
+        let res = await fetch(`${this.apiBaseUrl}/api/v2/text_messages?` + search, requestParams);
+
+        if (!res.ok) {
+            throw new Error("womp");
+        }
+
+        let messages = (await res.json()).data;
+        return this.pullMessagesFromData(messages, update);
     }
 
-    let auth = this.authCredentials();
-    let requestParams = Object.assign(auth, {
-      method: "POST",
-      body: JSON.stringify(body)
-    });
 
-    this.loading.send = true;
-    let res = await fetch(`${this.apiBaseUrl}/api/v2/participants/${this.participantId}/text_messages`, requestParams);
-    if (!res.ok) {
-      this.loading.older = false;
-      throw new Error("womp");
+
+    pullMessagesFromData(messages, update = true) {
+        if (update) {
+            // Our API call finds items updated after the lastUpdated, so if the lastUpdated matched the updated_at
+            // of a text we wouldn't get it. Move the search back by a second to account for that
+            this.meta.lastUpdated = dayjs().subtract(1, 'second').format('YYYY-MM-DD HH:mm:ss');
+        }
+
+        if (messages.length) {
+            let newMessages = messages.reduce((accumulator, text) => {
+                if (!this.meta.oldest || text.created_at < this.meta.oldest) {
+                    this.meta.oldest = text.created_at;
+                }
+                return {...accumulator, [text.id]: text};
+            }, {});
+            this.messagesObj = Object.assign({}, this.messagesObj, newMessages)
+        }
     }
-    let text = (await res.json()).data;
-    let obj = {};
-    obj[text.id] = text;
-
-    this.messagesObj = Object.assign({}, this.messagesObj, obj);
-    this.loading.send = false;
-  }
-};
 
 
-export default appState;
+
+    async loadMessages() {
+        if (this.loading.initial) {
+            return false;
+        }
+        this.loading.initial = true;
+        await this.loadMessagesViaParticipantApi(`limit(${this.meta.pageSize})`);
+        this.loading.initial = false;
+    }
+
+
+
+    async poll() {
+        if (this.loading.polling) {
+            return false;
+        }
+
+        this.loading.polling = true;
+        await this.loadMessagesViaParticipantApi(`updatedAfter(${this.meta.lastUpdated})`)
+        this.loading.polling = false;
+    }
+
+
+
+    async loadMessagesViaParticipantApi(textMessageCriteria) {
+        // use the participants endpoint for the initial load and when polling, so we get info on timezone, conversations,
+        // and messaging mode
+        let auth = this.authCredentials();
+        let requestParams = Object.assign(auth, {
+            method: "GET"
+        });
+        const includes = [
+            `text_messages:${textMessageCriteria}`,
+            'messaging_mode_session',
+            'current_conversation',
+        ];
+        const url = `${this.apiBaseUrl}/api/v2/participants/${this.participantId}?include=${includes.join(',')}`;
+        let res = await fetch(url, requestParams);
+        if (!res.ok) {
+            throw new Error("womp");
+        }
+        const ppt = (await res.json()).data;
+        inboxHelper.setTimezone(ppt?.time_zone_name ?? "America/New_York");
+        manualModeHelper.setCurrentSession(ppt?.messaging_mode_session);
+        manualModeHelper.setCurrentConversation(ppt?.current_conversation);
+        this.pullMessagesFromData(ppt.text_messages, true);
+
+    }
+
+
+
+    async loadOlder() {
+        if (this.loading.older) {
+            return false;
+        }
+
+        let params = {
+            created_at: 'before(' + this.meta.oldest + ')',
+        };
+
+        this.loading.older = true;
+        await this.fetchMessages(params, false);
+        this.loading.older = false;
+    }
+
+
+    async sendMessage(message, imageUrl) {
+        if (this.loading.send) {
+            return false;
+        }
+        let body = {
+            message_text: message,
+            media_url: imageUrl,
+            force: true
+        }
+
+        let auth = this.authCredentials();
+        let requestParams = Object.assign(auth, {
+            method: "POST",
+            body: JSON.stringify(body)
+        });
+
+        this.loading.send = true;
+        let res = await fetch(`${this.apiBaseUrl}/api/v2/participants/${this.participantId}/text_messages`, requestParams);
+        if (!res.ok) {
+            this.loading.older = false;
+            throw new Error("womp");
+        }
+        let text = (await res.json()).data;
+        let obj = {};
+        obj[text.id] = text;
+
+        this.messagesObj = Object.assign({}, this.messagesObj, obj);
+        this.loading.send = false;
+    }
+}
+
+export default InboxStore;


### PR DESCRIPTION
This component was built under the assumption that a page would only show one participant. On the Way to Health triage view, we show multiple participants and although the InboxComponent.vue wasn't being reused between participants, the inbox store was being reused, causing it to show messages from an old participant even when the store was now pointing to a new participant.

By switching to a class-based mechanism, we ensure that each instance of the inbox loads a separate store making sure that messages show in only the right context. It's up to the app to decide whether to persist multiple stores in memory or to instantiate a new one (and reload messages via API) when switching participants, but the store itself will always be confined to a single participant.